### PR TITLE
Update calendarEvents.js

### DIFF
--- a/routesCalendar/api/calendarEvents.js
+++ b/routesCalendar/api/calendarEvents.js
@@ -77,7 +77,7 @@ router.post('/', auth.required, function(req, res, next) {
 
       return calendarEvent.save().then(function(){
         //console.log(calendarEvent.owner);
-        calendarEvent.color=colorScheme; // ensure color scheme set to fully populated colorScheme converting to JSON
+        calendarEvent.color=colorScheme; // ensure color scheme set to fully populated colorScheme before converting to JSON
         return res.json({calendarEvent: calendarEvent.toJSONFor(user)});
       }); // end return calendarEvent.save
     }).catch(next); // end then ColorScheme.findById    


### PR DESCRIPTION
Post for a new CalendarEvent had intermittent failures ... was getting message "this.color.toJSONFor is not a function".  I suspect that population of the colorScheme for the new event was not being done properly on server before the JSON response of the posted CalendarEvent was returned to the caller.  Note, the event did get added.  I was only getting issues with generating the JSON response for it.

The code was modified in the way it deeply populated the color field.  I now explicitly do it using findByID for the passed colorscheme and this seems to work well.